### PR TITLE
feat: add CI github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
+    types: [opened, synchronize, reopened]
+jobs:
+  project-build-test:
+    uses: asimov-protocol/.github/.github/workflows/npm-ci.yml@v1.0
+    with:
+      skip-tests: true


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow configuration to the repository. The workflow is designed to run on specific events and leverages a reusable workflow for building and testing the project.

### CI Workflow Configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R13): Added a new workflow named `CI` that triggers on `push` and `pull_request` events targeting the `master` branch. It uses a reusable workflow (`npm-ci.yml`) from the `asimov-protocol` repository, with the `skip-tests` option set to `true`.