### PR TITLE
fix: hero image source

### DIFF
--- a/src/components/Hero.svelte
+++ b/src/components/Hero.svelte
@@ -14,7 +14,7 @@
 
 <section
 	class="relative flex h-screen items-center bg-cover bg-center bg-no-repeat"
-	style="background-image: url('/src/assets/hero-cover.png');"
+	style="background-image: url('/hero-cover.png');"
 >
 	<div class="bg-sSlate-950 absolute inset-0 opacity-35"></div>
 


### PR DESCRIPTION
This pull request includes a minor update to the `Hero.svelte` component. The change updates the file path for the hero section's background image to simplify the directory structure.

* [`src/components/Hero.svelte`](diffhunk://#diff-ba775d0b46e9da9b178b7f6326714989b2ae4fc24593443063dea2221ca38d60L17-R17): Updated the `background-image` URL from `/src/assets/hero-cover.png` to `/hero-cover.png` to reflect the new file path.