### PR TITLE
chore: add legal company name

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -130,6 +130,9 @@
 							{CONTACT_US_EMAIL}
 						</a>
 					</li>
+					<li class="cursor-default">
+						<span class="not-italic">ASIMOV Systems, Inc.</span>
+					</li>
 					<li
 						class="hover:text-oOrange-500 cursor-default transition-all duration-300 hover:translate-x-2"
 					>


### PR DESCRIPTION
This pull request adds a new item to the footer of the application to display the company name.

* [`src/components/Footer.svelte`](diffhunk://#diff-be8cd3952647a474ae4a2a9546130b34985932dfc7aba1238509e055ff2c0d90R133-R135): Added a new list item with the company name "ASIMOV Systems, Inc." displayed using an `<address>` tag.