### PR TITLE
fix: attemp to fix metatags

### DIFF
--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -32,20 +32,12 @@ const {
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
 
-    <!-- Open Graph -->
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content="https://asimov.systems/og-image.png" />
-    <meta property="og:url" content="https://asimov.systems/" />
-    <meta property="og:type" content="website" />
+    <!-- Default meta tags (can be overridden by pages) -->
+    <title>{title}</title>
+    <meta name="description" content={description} />
 
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content="https://asimov.systems/og-image.png" />
-    <meta name="twitter:site" content="@ASIMOV_Protocol" />
     <ClientRouter />
+    <slot name="head" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,8 +1,32 @@
 ---
 import Layout from '@/layouts/main.astro';
 import { Contact } from '@/components/Contact';
+
+const title = 'Contact - ASIMOV Systems';
+const description =
+  'Get in touch with ASIMOV Systems. Contact us for questions about our AI tools for thinking better and working faster.';
+const canonicalUrl = 'https://asimov.systems/contact';
 ---
 
-<Layout title="Contact - ASIMOV Systems">
+<Layout title={title} description={description}>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://asimov.systems/og-image.png" />
+
+    <!-- Twitter -->
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="https://asimov.systems/og-image.png" />
+    <meta name="twitter:image:alt" content="ASIMOV Systems - Contact Us" />
+    <meta name="twitter:site" content="@ASIMOV_Protocol" />
+  </Fragment>
+
   <Contact />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,9 +14,36 @@ import { Resources } from '@/components/Resources';
 // import { RecentPosts } from '@/components/RecentPosts';
 import { TGE } from '@/components/TGE';
 import { GetInTouch } from '@/components/GetInTouch';
+
+const title = 'ASIMOV.Systems - AI Tools for Thinking Better & Working Faster';
+const description =
+  'Tools for thinking better, working faster, and cutting through the noise. Built for people who want more clarity and less chaos. AI that remembers what matters and respects your data.';
+const canonicalUrl = 'https://asimov.systems/';
 ---
 
-<Layout>
+<Layout title={title} description={description}>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content="https://asimov.systems/og-image.png" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content="https://asimov.systems/og-image.png" />
+    <meta
+      name="twitter:image:alt"
+      content="ASIMOV Systems - AI Tools for Thinking Better & Working Faster"
+    />
+    <meta name="twitter:site" content="@ASIMOV_Protocol" />
+  </Fragment>
+
   <Hero client:load />
   <Problem />
   <Solution />

--- a/src/pages/investors.astro
+++ b/src/pages/investors.astro
@@ -2,9 +2,33 @@
 import Layout from '@/layouts/main.astro';
 import { InvestorIntro } from '@/components/InvestorIntro';
 import { InvestorForm } from '@/components/InvestorForm';
+
+const title = 'Investors - ASIMOV Systems';
+const description =
+  'Join ASIMOV Systems as an investor. Learn about our mission to build verifiable AI tools for thinking better and working faster.';
+const canonicalUrl = 'https://asimov.systems/investors';
 ---
 
-<Layout title="Investors - ASIMOV Systems">
+<Layout title={title} description={description}>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://asimov.systems/og-image.png" />
+
+    <!-- Twitter -->
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="https://asimov.systems/og-image.png" />
+    <meta name="twitter:image:alt" content="ASIMOV Systems Investors" />
+    <meta name="twitter:site" content="@ASIMOV_Protocol" />
+  </Fragment>
+
   <InvestorIntro client:load />
   <InvestorForm client:load />
 </Layout>

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -1,11 +1,32 @@
 ---
 import Layout from '../layouts/main.astro';
 import { TeamPage } from '@/components/TeamPage';
+
+const title = 'Team - ASIMOV Systems';
+const description =
+  'Meet the minds behind ASIMOV Systems - a diverse team of entrepreneurs, engineers, and visionaries building verifiable AI that serves humanity, not surveillance.';
+const canonicalUrl = 'https://asimov.systems/team';
 ---
 
-<Layout
-  title="Team - ASIMOV Systems"
-  description="Meet the minds behind ASIMOV Systems - a diverse team of entrepreneurs, engineers, and visionaries building verifiable AI that serves humanity, not surveillance."
->
+<Layout title={title} description={description}>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://asimov.systems/og-image.png" />
+
+    <!-- Twitter -->
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="https://asimov.systems/og-image.png" />
+    <meta name="twitter:image:alt" content="ASIMOV Systems Team" />
+    <meta name="twitter:site" content="@ASIMOV_Protocol" />
+  </Fragment>
+
   <TeamPage client:load />
 </Layout>


### PR DESCRIPTION
This pull request standardizes and improves how meta tags are handled across the main site layout and key pages. The main change is moving Open Graph and Twitter meta tags from the global layout into individual pages, allowing each page to specify its own metadata for better SEO and social sharing. Additionally, canonical URLs are now set per page. The layout file now provides only default meta tags, and exposes a slot for pages to inject their own head content.

**Meta tag handling improvements:**

* Removed global Open Graph and Twitter meta tags from `src/layouts/main.astro`, and added a `<slot name="head" />` to allow pages to inject custom metadata.
* Added page-specific Open Graph, Twitter, and canonical meta tags to `src/pages/index.astro`, `src/pages/contact.astro`, `src/pages/investors.astro`, and `src/pages/team.astro`, making metadata more accurate and relevant for each page. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R17-R46) [[2]](diffhunk://#diff-163c854c0a342f227d230bdc374693db58f1587a69b4cf01c74652585b54a179R4-R30) [[3]](diffhunk://#diff-1f7f0c8695dc3d8b61863f1f47976a48a3b524895ad132e52f1e9bc3f125436fR5-R31) [[4]](diffhunk://#diff-ccf8c8df2aa56b16016dea7ca39f9d530fc8b116c00ed15105ab839b0840db5aR4-R30)

**SEO and social sharing enhancements:**

* Each page now sets its own `title`, `description`, and `canonicalUrl` variables, which are used in both the layout and meta tags for improved SEO. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R17-R46) [[2]](diffhunk://#diff-163c854c0a342f227d230bdc374693db58f1587a69b4cf01c74652585b54a179R4-R30) [[3]](diffhunk://#diff-1f7f0c8695dc3d8b61863f1f47976a48a3b524895ad132e52f1e9bc3f125436fR5-R31) [[4]](diffhunk://#diff-ccf8c8df2aa56b16016dea7ca39f9d530fc8b116c00ed15105ab839b0840db5aR4-R30)
* Twitter meta tags now include descriptive `twitter:image:alt` attributes for better accessibility and richer social previews. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R17-R46) [[2]](diffhunk://#diff-163c854c0a342f227d230bdc374693db58f1587a69b4cf01c74652585b54a179R4-R30) [[3]](diffhunk://#diff-1f7f0c8695dc3d8b61863f1f47976a48a3b524895ad132e52f1e9bc3f125436fR5-R31) [[4]](diffhunk://#diff-ccf8c8df2aa56b16016dea7ca39f9d530fc8b116c00ed15105ab839b0840db5aR4-R30)